### PR TITLE
Add serverless login endpoint and dynamic API base configuration

### DIFF
--- a/api/auth/login.js
+++ b/api/auth/login.js
@@ -1,0 +1,25 @@
+export default function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', ['POST']);
+    return res.status(405).end(`Method ${req.method} Not Allowed`);
+  }
+
+  const { email, password } = req.body || {};
+
+  const users = {
+    'admin@school.com': { name: 'João Diretor', role: 'Manager', password: 'admin123' },
+    'maria@school.com': { name: 'Maria Silva', role: 'Receptionist', password: 'maria123' },
+    'carlos@school.com': { name: 'Carlos Souza', role: 'Coordinator', password: 'carlos123' },
+    'ana@school.com': { name: 'Ana Costa', role: 'Sales Rep', password: 'ana123' },
+  };
+
+  const user = users[email];
+  if (!user || user.password !== password) {
+    return res.status(401).json({ detail: 'Invalid credentials' });
+  }
+
+  return res.status(200).json({
+    token: `mocktoken-${email}`,
+    user: { email, name: user.name, role: user.role },
+  });
+}

--- a/frontend/src/components/Login.js
+++ b/frontend/src/components/Login.js
@@ -12,7 +12,15 @@ import {
   AlertCircle
 } from 'lucide-react';
 
-const API_BASE = process.env.REACT_APP_BACKEND_URL || 'http://localhost:8001';
+// Determine API base URL.
+// - Use REACT_APP_BACKEND_URL if provided
+// - Use local backend during development
+// - Fallback to same-origin when deployed
+const API_BASE =
+  process.env.REACT_APP_BACKEND_URL ||
+  (typeof window !== 'undefined' && window.location.hostname === 'localhost'
+    ? 'http://localhost:8001'
+    : '');
 
 const Login = ({ onLogin }) => {
   const [formData, setFormData] = useState({


### PR DESCRIPTION
## Summary
- add Vercel serverless function for `/api/auth/login`
- detect runtime host to choose appropriate API base URL

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6897517bfcfc8322a5f293e7fca8a26a